### PR TITLE
ESDLPlots is not compatible with Compose < 0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,3 +23,6 @@ Shapefile = "8e980c4a-a4fe-5da2-b3a7-4b4b0353a2f4"
 Showoff = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Widgets = "cc8bc4a8-27d6-5769-a93b-9d913e69aa62"
+
+[compat]
+Compose = "0.8


### PR DESCRIPTION
I was unable to import ESDLPlots with Compose 0.6.x. By updating to Compose 0.8, I am able to import the package.